### PR TITLE
RIP GO GO IN FLIGHT WIFI SCREW YOU (#222)

### DIFF
--- a/Source/References/AudioPlayr-0.2.1.js
+++ b/Source/References/AudioPlayr-0.2.1.js
@@ -89,7 +89,7 @@ var AudioPlayr;
          * @returns The current volume as a Number in [0,1], retrieved by the ItemsHoldr.
          */
         AudioPlayr.prototype.getVolume = function () {
-            return Number(this.ItemsHolder.getItem("volume") || 0);
+            return parseFloat(this.ItemsHolder.getItem("volume")) || 1;
         };
         /**
          * Sets the current volume. If not muted, all sounds will have their volume

--- a/Source/References/AudioPlayr-0.2.1.ts
+++ b/Source/References/AudioPlayr-0.2.1.ts
@@ -439,7 +439,7 @@ module AudioPlayr {
          * @returns The current volume as a Number in [0,1], retrieved by the ItemsHoldr.
          */
         getVolume(): number {
-            return Number(this.ItemsHolder.getItem("volume") || 0);
+            return parseFloat(this.ItemsHolder.getItem("volume")) || 1;
         }
 
         /**

--- a/Source/settings/maps/Route 22.js
+++ b/Source/settings/maps/Route 22.js
@@ -86,7 +86,7 @@ FullScreenPokemon.FullScreenPokemon.settings.maps.library["Route 22"] = {
                 { "thing": "Ledge", "x": 272, "y": 108, "width": 32 },
                 { "thing": "BrickRoad", "x": 16, "y": 112, "width": 288, "height": 16 },
                 { "thing": "Mountain", "y": 128, "width": 16, "height": 16 },
-                { "thing": "Mountain", "x": 16, "y": 128, "width": 288, "height": 16, "top": true },
+                { "macro": "Mountain", "x": 16, "y": 128, "width": 288, "height": 16, "top": true },
                 { "thing": "Mountain", "x": 304, "y": 128, "width": 16, "height": 16 }
             ]
         }

--- a/Source/settings/math.js
+++ b/Source/settings/math.js
@@ -9356,51 +9356,38 @@ var FullScreenPokemon;
                     "moves": {
                         "natural": [
                             {
-                                "move": "Toxic",
-                                "level": 6
-                            }, {
-                                "move": "Body Slam",
+                                "move": "Growl",
+                                "level": 1
+                            },
+                            {
+                                "move": "Tackle",
+                                "level": 1
+                            },
+                            {
+                                "move": "Scratch",
                                 "level": 8
-                            }, {
-                                "move": "Take Down",
-                                "level": 9
-                            }, {
-                                "move": "Double-Edge",
-                                "level": 10
-                            }, {
-                                "move": "Blizzard",
-                                "level": 14
-                            }, {
-                                "move": "Rage",
-                                "level": 20
-                            }, {
-                                "move": "Thunderbolt",
-                                "level": 24
-                            }, {
-                                "move": "Thunder",
-                                "level": 25
-                            }, {
-                                "move": "Mimic",
-                                "level": 31
-                            }, {
-                                "move": "Double Team",
-                                "level": 32
-                            }, {
-                                "move": "Reflect",
-                                "level": 33
-                            }, {
-                                "move": "Bide",
-                                "level": 34
-                            }, {
-                                "move": "Skull Bash",
-                                "level": 40
-                            }, {
-                                "move": "Rest",
-                                "level": 44
-                            }, {
-                                "move": "Substitute",
-                                "level": 50
-                            }],
+                            },
+                            {
+                                "move": "Double Kick",
+                                "level": 12
+                            },
+                            {
+                                "move": "Poison Sting",
+                                "level": 17
+                            },
+                            {
+                                "move": "Tail Whip",
+                                "level": 23
+                            },
+                            {
+                                "move": "Bite",
+                                "level": 30
+                            },
+                            {
+                                "move": "Fury Swipes",
+                                "level": 38
+                            },
+                        ],
                         "hm": [
                             {
                                 "move": "Toxic",

--- a/Source/settings/math.ts
+++ b/Source/settings/math.ts
@@ -9515,51 +9515,38 @@ module FullScreenPokemon {
                     "moves": {
                         "natural": [
                             {
-                                "move": "Toxic",
-                                "level": 6
-                            }, {
-                                "move": "Body Slam",
+                                "move": "Growl",
+                                "level": 1
+                            },
+                            {
+                                "move": "Tackle",
+                                "level": 1
+                            },
+                            {
+                                "move": "Scratch",
                                 "level": 8
-                            }, {
-                                "move": "Take Down",
-                                "level": 9
-                            }, {
-                                "move": "Double-Edge",
-                                "level": 10
-                            }, {
-                                "move": "Blizzard",
-                                "level": 14
-                            }, {
-                                "move": "Rage",
-                                "level": 20
-                            }, {
-                                "move": "Thunderbolt",
-                                "level": 24
-                            }, {
-                                "move": "Thunder",
-                                "level": 25
-                            }, {
-                                "move": "Mimic",
-                                "level": 31
-                            }, {
-                                "move": "Double Team",
-                                "level": 32
-                            }, {
-                                "move": "Reflect",
-                                "level": 33
-                            }, {
-                                "move": "Bide",
-                                "level": 34
-                            }, {
-                                "move": "Skull Bash",
-                                "level": 40
-                            }, {
-                                "move": "Rest",
-                                "level": 44
-                            }, {
-                                "move": "Substitute",
-                                "level": 50
-                            }],
+                            },
+                            {
+                                "move": "Double Kick",
+                                "level": 12
+                            },
+                            {
+                                "move": "Poison Sting",
+                                "level": 17
+                            },
+                            {
+                                "move": "Tail Whip",
+                                "level": 23
+                            },
+                            {
+                                "move": "Bite",
+                                "level": 30
+                            },
+                            {
+                                "move": "Fury Swipes",
+                                "level": 38
+                            },
+                        ],
                         "hm": [
                             {
                                 "move": "Toxic",

--- a/Source/settings/objects.js
+++ b/Source/settings/objects.js
@@ -998,7 +998,11 @@ FullScreenPokemon.FullScreenPokemon.settings.objects = {
             "nocollide": true
         },
         "MountainSolidBase": [4, 4],
-        "MountainTop": [4, 5],
+        "MountainTop": {
+            "width": 4,
+            "height": 5,
+            "tolBottom": FullScreenPokemon.FullScreenPokemon.unitsize * -3
+        },
         "PlantLarge": [16, 16],
         "PokeCenterDeskBlocker": {
             "width": 8,


### PR DESCRIPTION
- Fixed NIDORANFemaleSymbol's natural moves

Fixes #221
- Fixed cycling going through walls

Flying through the air at hundreds of miles an hour,  with an altitude
of 37,005 feet, it is finally fixed.

Borders needed to be accounted for more accurately. Lower speeds were
fine because the player would still be found as within the region after
overlapping, but higher speeds let the player just blow past the guards.

Fixes #178
- Fix for accessible mountaintop below Route 22

Also added a negative tolBottom to the MountainTop Solid so it doesn't
get all weird walking below it.

Fixes #220
- Stopped bagActivate methods while player is walking
- Standardized default AudioPlayr volume to 1

When localStorage is cleared on a New Game, it makes sense to keep the
volume the same as the constructor's default of 1.

Fixes #219
- Fixed overlap detection for collision detectors

Fixes #202
- Added walking forward step back to surfing

It was missing as a result of the new bordering checks.
- Prevented cycling while surfing
